### PR TITLE
Unreferenced variable "through"

### DIFF
--- a/js/jsonh.js
+++ b/js/jsonh.js
@@ -80,7 +80,7 @@ var JSONH, jsonh = JSONH = function (Array, JSON) {"use strict"; // if you want
                 if (isArray(tmp = current[k = path[i]])) {
                     j = i + 1;
                     current[k] = j < length ?
-                        map.call(tmp, through, path.slice(j)) :
+                        map.call(tmp, method, path.slice(j)) :
                         method(tmp)
                     ;
                 }


### PR DESCRIPTION
I just tried some random uses of JSONH, and it throws a "ReferenceError: through is not defined" exception when I try to specify longer keys schema than expected.

Test case: `jsonh.stringify([{a:[[{b:12}]]}], null, null, ['a.c'])`

I tried to fix that but I am not sure if this is the expected behavior for longer (wrong?) schema keys.
