### PR TITLE
#pack shouldn't blow up if passed an empty array.

### DIFF
--- a/rb/jsonh.rb
+++ b/rb/jsonh.rb
@@ -34,6 +34,7 @@ module JSONH
   end
 
   def pack(hlist)
+    return [] if hlist.empty?
     keys = hlist.first.keys
     [keys.size, *keys, *hlist.map(&:values).flatten(1)]
   end


### PR DESCRIPTION
- return the empty array instead of raising NoMethodError keys on nil
