### PR TITLE
Passes to json_decode the $assoc value given to ::parse()

### DIFF
--- a/php5/JSONH.class.php
+++ b/php5/JSONH.class.php
@@ -44,7 +44,7 @@ class JSONH {
         /*int /*use type hint if you can removing initial comment*/
         $options = 0
     ) {
-        return self::unpack(json_decode($hlist), $assoc, $depth, $options);
+        return self::unpack(json_decode($hlist, $assoc), $assoc, $depth, $options);
     }
     
     public static function stringify(


### PR DESCRIPTION
Without this change, jsonh_decode() did not behave as expected,
mirroring json_decode()'s "array mode".

json_decode would assume that we want
to decode as stdObj, even if we are telling jsonh_decode
to return arrays.

http://php.net/manual/en/function.json-decode.php
http://stackoverflow.com/questions/5164404/json-decode-to-array
